### PR TITLE
Ignore windows that are not put on the pager

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -1,11 +1,11 @@
 var LOCK = false;
 
 function desktops() {
-  return workspace.clientList().reduce(function(n, w) { return Math.max(n, w.desktop); }, -1);
+  return workspace.clientList().reduce(function(n, w) { return Math.max(n, w.skipPager ? -1 : w.desktop); }, -1);
 }
 
 function winsInDesktop(d) {
-  return workspace.clientList().filter(function(w) { return w.desktop == d; });
+  return workspace.clientList().filter(function(w) { return w.desktop == d && !w.skipPager; });
 }
 
 function winsFromDesktop(d) {


### PR DESCRIPTION
Previously, windows such as the start menu and calendar were treated as
normal windows. As a result, opening the start menu on a desktop edge
would cause a weird desktop animation and sometimes crash kwin.

Now, any window that does not want to be part of the pager is ignored
when deciding if a new desktop should be created on either end.

Fixes #2 