### PR TITLE
[WIP] Allow to manually enable empty desktop at front and/or back

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -26,12 +26,17 @@ function pullWinsFromDesktop(n) {
 }
 
 function updateDesktops() {
-  if (winsInDesktop(1).length > 0)
-    pushWinsFromDesktop(0);
-  for (var i = 2; i <= workspace.desktops; i++)
+  var showInFront = readConfig('showEmptyDesktopInFront', true);
+  var showAtBack = readConfig('showEmptyDesktopAtBack', true);
+  print(showInFront);
+  print(showAtBack);
+  if (showInFront)
+    if (winsInDesktop(1).length > 0)
+      pushWinsFromDesktop(0);
+  for (var i = (showInFront ? 2 : 1); i <= workspace.desktops; i++)
     if (i != workspace.currentDesktop && winsInDesktop(i).length == 0)
       pullWinsFromDesktop(i);
-  workspace.desktops = Math.max(readConfig('minimumDesktops', 1), desktops() + 1);
+  workspace.desktops = Math.max(readConfig('minimumDesktops', 1), desktops() + (showAtBack ? 1 : 0));
 }
 
 function update() {

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -9,5 +9,13 @@
       <label>The minimum amount of desktops</label>
       <default>1</default>
     </entry>
+    <entry name="showEmptyDesktopInFront" type="bool">
+      <label>Always show an empty desktop in front</label>
+      <default>true</default>
+    </entry>
+    <entry name="showEmptyDesktopAtBack" type="bool">
+      <label>Always show an empty desktop at the back</label>
+      <default>true</default>
+    </entry>
   </group>
 </kcfg>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -12,6 +12,20 @@
    <item row="0" column="1">
     <widget class="QLineEdit" name="kcfg_minimumDesktops"/>
    </item>
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="kcfg_showEmptyDesktopInFront">
+     <property name="text">
+      <string>Show empty desktop in front</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="kcfg_showEmptyDesktopAtBack">
+     <property name="text">
+      <string>Show empty desktop at back</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
 </ui>


### PR DESCRIPTION
(More than) Solution for #3 .

If removing the configuration-related parts, it works correctly.

However, the configuration doesn't seem to read successfully in `code/main.js`.
Neither could I get the output of `print()`.

Does anyone have any idea?